### PR TITLE
Fix can't access property "destroy", this._barrier is null

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -85,9 +85,11 @@ const BottomEdge = GObject.registerClass(
                 this._barrierTimeout = null;
             }
 
-            this._pressureBarrier?.removeBarrier(this._barrier);
-            this._barrier.destroy();
-            this._barrier = null;
+            if (this._barrier) {
+                this._pressureBarrier?.removeBarrier(this._barrier);
+                this._barrier.destroy();
+                this._barrier = null;
+            }
         }
 
         destroy() {


### PR DESCRIPTION
When rearranging displays, certain configurations can cause the error below, which then crashes the entire extension.

**From**
<img width="942" height="513" alt="gnome-display-rearrange-left" src="https://github.com/user-attachments/assets/72604b63-af67-437c-94dc-b2981e0e70fb" />

**To**
<img width="942" height="513" alt="gnome-display-rearrange-mid" src="https://github.com/user-attachments/assets/c378bedd-a135-41c5-a30f-fa01bd98c7cc" />

```
JS ERROR: TypeError: can't access property "destroy", this._barrier is null
_removeBarrier@file:///~/.local/share/gnome-shell/extensions/bottom-dash-panel@fthx/extension.js:89:13
destroy@file:///~/.local/share/gnome-shell/extensions/bottom-dash-panel@fthx/extension.js:96:18
destroy@file:///~/.local/share/gnome-shell/extensions/bottom-dash-panel@fthx/extension.js:277:38
_clean/<@file:///~/.local/share/gnome-shell/extensions/bottom-dash-panel@fthx/extension.js:348:61
_clean@file:///~/.local/share/gnome-shell/extensions/bottom-dash-panel@fthx/extension.js:348:32
_refresh@file:///~/.local/share/gnome-shell/extensions/bottom-dash-panel@fthx/extension.js:326:18
_init/<@file:///~/.local/share/gnome-shell/extensions/bottom-dash-panel@fthx/extension.js:308:77
_monitorsChanged@resource:///org/gnome/shell/ui/layout.js:611:14
@resource:///org/gnome/shell/ui/init.js:21:20
```

The added `if (this._barrier) {` block keeps the extension running and allows it to refresh correctly.